### PR TITLE
:bug: (修复 WooCommerce 冲突)

### DIFF
--- a/inc/base.php
+++ b/inc/base.php
@@ -64,7 +64,7 @@ function ews_login($code){
                         $user_login = $user->user_login;
                         wp_set_auth_cookie($user_ID,true,is_ssl());
                         wp_signon( array(), is_ssl() );
-                        do_action('wp_login', $user_login);
+                        do_action('wp_login', $user_login ,$user);
                         return true;
                     }else{
                         $login_name = "u".mt_rand(1000,9999).mt_rand(1000,9999).mt_rand(1000,9999).mt_rand(1000,9999);
@@ -83,7 +83,7 @@ function ews_login($code){
                                 }
                                 wp_set_auth_cookie($user_ID,true,is_ssl());
                                 wp_signon( array(), is_ssl() );
-                                do_action('wp_login', $login_name);
+                                do_action('wp_login', $login_name, $user);
                                 return true;
                             }
                         }
@@ -105,7 +105,7 @@ function ews_login($code){
                             }
                             wp_set_auth_cookie($user_ID,true,is_ssl());
                             wp_signon( array(), is_ssl() );
-                            do_action('wp_login', $login_name);
+                            do_action('wp_login', $login_name, $user);
                             return true;
                         }
                     }


### PR DESCRIPTION
安装 WooCommerce 商城插件时，通过 ajax 请求 wp-admin 登录时会报错。原因是 `do_action('wp_login', $user_login);` 缺少第三个可选参数 `$user`，WooCommerce 登录需要这玩意。

![image](https://user-images.githubusercontent.com/30286980/188273445-f2015523-2c41-45b4-9f6b-52c4dd8d270f.png)
